### PR TITLE
feat: Add visibility toggle to password inputs

### DIFF
--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,39 @@
+import React, {useMemo, useState} from 'react';
+import {TextInput} from 'react-native-paper';
+
+interface Props {
+  password: string,
+  setPassword: (newPassword: string) => void,
+  label: string,
+  error?: boolean,
+}
+
+const ICON_INPUT_HIDDEN = 'eye-off';
+const ICON_INPUT_VISIBLE = 'eye';
+
+export const PasswordInput = (props: Props) => {
+  const [inputHidden, setInputHidden] = useState<boolean>(true);
+
+  const toggleHiddenIcon = useMemo(
+      () => (
+        <TextInput.Icon
+          icon={inputHidden ? ICON_INPUT_HIDDEN : ICON_INPUT_VISIBLE}
+          onPress={() => setInputHidden(!inputHidden)}
+          forceTextInputFocus={false}
+        />
+      ), [inputHidden],
+  );
+
+  return (
+    <TextInput
+      dense={true}
+      mode="flat"
+      value={props.password}
+      onChangeText={props.setPassword}
+      label={props.label}
+      error={props.error}
+      secureTextEntry={inputHidden}
+      right={toggleHiddenIcon}
+    />
+  );
+};

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {TextInput} from 'react-native-paper';
 
 interface Props {
@@ -14,11 +14,16 @@ const ICON_INPUT_VISIBLE = 'eye';
 export const PasswordInput = (props: Props) => {
   const [inputHidden, setInputHidden] = useState<boolean>(true);
 
+  const toggleInputHidden = useCallback(
+      () => setInputHidden(!inputHidden),
+      [inputHidden],
+  );
+
   const toggleHiddenIcon = useMemo(
       () => (
         <TextInput.Icon
           icon={inputHidden ? ICON_INPUT_HIDDEN : ICON_INPUT_VISIBLE}
-          onPress={() => setInputHidden(!inputHidden)}
+          onPress={toggleInputHidden}
           forceTextInputFocus={false}
         />
       ), [inputHidden],

--- a/src/components/PasswordValidationInput.tsx
+++ b/src/components/PasswordValidationInput.tsx
@@ -1,11 +1,12 @@
 import React, {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import {HelperText, TextInput} from 'react-native-paper';
+import {HelperText} from 'react-native-paper';
 import Spacer from 'react-spacer';
+import {PasswordInput} from './PasswordInput';
 
 interface Props {
-    onValidityChange: (valid: boolean) => void;
-    onPasswordChange: (newPassword: string) => void;
+  onValidityChange: (valid: boolean) => void;
+  onPasswordChange: (newPassword: string) => void;
 }
 
 export const PasswordValidationInput = (props: Props) => {
@@ -28,22 +29,16 @@ export const PasswordValidationInput = (props: Props) => {
 
   return (
     <>
-      <TextInput
-        dense={true}
-        mode="flat"
-        value={password}
-        onChangeText={setPassword}
-        label={t('screens.login.password')}
-        secureTextEntry={true} />
+      <PasswordInput
+        password={password}
+        setPassword={setPassword}
+        label={t('screens.login.password')} />
       <Spacer height={5} />
-      <TextInput
-        dense={true}
-        mode="flat"
-        value={confirmedPassword}
-        onChangeText={setConfirmedPassword}
+      <PasswordInput
+        password={confirmedPassword}
+        setPassword={setConfirmedPassword}
         label={t('screens.login.passwordConfirm')}
-        error={!passwordsMatching}
-        secureTextEntry={true} />
+        error={!passwordsMatching} />
 
       <HelperText type="error" visible={!passwordsMatching} >{t('screens.login.errorNoPasswordMatch')}</HelperText>
     </>

--- a/src/screens/LoginScreen/LoginScreen.tsx
+++ b/src/screens/LoginScreen/LoginScreen.tsx
@@ -13,6 +13,7 @@ import {login} from '../../redux/features/authSlice';
 import CentralStyles, {OwnColors} from '../../styles/CentralStyles';
 import {LoginBackdrop} from './LoginBackdrop';
 import {Button, Card, IconButton, Modal, Text, TextInput, useTheme} from 'react-native-paper';
+import {PasswordInput} from '../../components/PasswordInput';
 
 
 type Props = NativeStackScreenProps<LoginNavigationProps, 'LoginScreen'>;
@@ -77,9 +78,9 @@ const LoginScreen = ({route, navigation}: Props) => {
       <View style={styles.loginContainer}>
         <View style={CentralStyles.smallContentContainer}>
           <Text style={CentralStyles.loginTitle}>CookPal</Text>
-          <TextInput mode="flat" dense={true} value={email} keyboardType='email-address' onChangeText={(text) => setEmail(text)} label="E-Mail"/>
+          <TextInput mode="flat" dense={true} value={email} keyboardType='email-address' onChangeText={(text) => setEmail(text)} label="E-Mail" />
           <Spacer height={10} />
-          <TextInput mode="flat" dense={true} value={password} onChangeText={(text) => setPassword(text)} label="Password" secureTextEntry={true} />
+          <PasswordInput password={password} setPassword={setPassword} label={t('screens.login.password')} />
           <View style={styles.forgotPasswordContainer}>
             <Button
               color={OwnColors.bluishGrey}


### PR DESCRIPTION
Looks like this:
![grafik](https://user-images.githubusercontent.com/72548231/208294486-3550cbd3-1c82-4859-ad44-b2d558882dfb.png)

The two passwords on the register screen can be toggled independently. Personally, I think that's fine - but if you want, then we can increase the complexity by changing this to a single toggle for both input fields.